### PR TITLE
Fixed nats-1 dependency.

### DIFF
--- a/positive.cabal
+++ b/positive.cabal
@@ -21,7 +21,7 @@ source-repository head
 library
     build-depends:
         base            >= 4 && < 5,
-        nats            >= 0.2 && < 1,
+        nats            >= 0.2 && <= 1,
         semigroups      >= 0.15.2 && < 1
     hs-source-dirs:     src
     default-language:   Haskell2010

--- a/src/Numeric/Positive.hs
+++ b/src/Numeric/Positive.hs
@@ -16,12 +16,12 @@ newtype Positive = Positive { getPositive :: Natural } deriving
     Eq,
     Ord,
     -- Data,
-    Real,
+    Real
     -- Ix,
     -- Typeable,
     -- Bits,
     -- Hashable,
-    Whole
+    -- Whole
     )
 
 instance Show Positive where
@@ -67,4 +67,3 @@ nonEmptyLength = fromIntegral . NonEmpty.length
 
 -- _nonEmpty :: Prism [a] [b] (NonEmpty a) (NonEmpty b)
 -- _nonEmpty :: prism' NonEmpty.toList (\x -> if lenght x > 0 then Just (NonEmpty.fromList x) else Nothing)
-


### PR DESCRIPTION
The package nats was recently updated to version 1. The difference between this and the preceding version was the use of the Whole typeclass. I fixed the code removing that derivation, and bumping nats constraints in the cabal file.
